### PR TITLE
Strut hierarchy redo

### DIFF
--- a/Delorean/HoverAnimate.txt
+++ b/Delorean/HoverAnimate.txt
@@ -13,6 +13,7 @@ float ground
 float extension
 float pivot
 float piston_ext
+float piston_angle
 float damper
 int ignore
 

--- a/Delorean/Include/Hover.txt
+++ b/Delorean/Include/Hover.txt
@@ -24,7 +24,7 @@ then
                 var2 == FLYING_LANDING_BIT // Landing
             then
                 // Don't convert if we're still animating
-                3F1B: get_car vehicle component "strutrb" pos x y z
+                3F1B: get_car vehicle component "strutunitrb_" pos x y z
                 0097: abs x
                 if or
                     x >= 0.01
@@ -37,7 +37,7 @@ then
                 0B11: vehicle_flags = vehicle_flags OR FLYING_TAKEOFF_BIT
                 stream_custom_script "Delorean/HoverAnimate.s" vehicle vehicle_flags
             else if
-                3F1C: get_car vehicle component "fxwheelrb_" rotation  x y z
+                3F1C: get_car vehicle component "hoverjointrb_" rotation  x y z
                 0097: abs y
                 if
                     y < 89.0
@@ -74,7 +74,7 @@ cleo_return 1 vehicle_flags
 
 :CheckHoverAnimation
 0B10: var1 = vehicle_flags AND FLYING_BIT   // Is car flying?
-3F1C: get_car vehicle component "fxwheelrb_" rotation var2 var3 var4
+3F1C: get_car vehicle component "hoverjointrb_" rotation var2 var3 var4
 0097: abs var3
 if and
     var1 == FLYING_TAKEOFF_BIT
@@ -134,7 +134,7 @@ then
     cleo_call @WheelGlow 3 vehicle alpha 255 step 5
 else
     // Fade out wheel lights once wheels are unfolded
-    3F1C: get_car vehicle component "fxwheelrb_" rotation var1 var2 var3
+    3F1C: get_car vehicle component "hoverjointrb_" rotation var1 var2 var3
     if
         var2 == 0.0
     then
@@ -217,7 +217,7 @@ then
 end
 
 // Wheel Thruster
-3F1C: get_car vehicle component "fxwheelrb_" rotation x y z
+3F1C: get_car vehicle component "hoverjointrb_" rotation x y z
 0097: abs y
 3F66: get_joypad 0 throttle_to var1 var2
 if and

--- a/Delorean/Include/HoverAnimateModel.txt
+++ b/Delorean/Include/HoverAnimateModel.txt
@@ -13,49 +13,37 @@ damper /= -0.3
 damper += 1.0
 
 // Extend
-3F14: set_car vehicle component "strutshockrb"    pos extension 0.0 0.0
 3F14: set_car vehicle component "shockpistonrb"   pos 0.0 0.0 piston_ext
 3F1B: get_car vehicle component "wheel_rb_dummy"  pos x y z
 z -= WHEEL_BZ_OFFSET
 z *= damper
-3F14: set_car vehicle component "strutrb"         pos extension 0.0 z
+3F14: set_car vehicle component "strutunitrb_"    pos extension 0.0 z
 
-3F14: set_car vehicle component "strutshockrf"    pos extension 0.0 0.0
 3F14: set_car vehicle component "shockpistonrf"   pos 0.0 0.0 piston_ext
 3F1B: get_car vehicle component "wheel_rf_dummy"  pos x y z
 z -= WHEEL_FZ_OFFSET
 z *= damper
-3F14: set_car vehicle component "strutrf"         pos extension 0.0 z
+3F14: set_car vehicle component "strutunitrf_"    pos extension 0.0 z
 
 extension *= -1.0
-3F14: set_car vehicle component "strutshocklb"    pos extension 0.0 0.0
 3F14: set_car vehicle component "shockpistonlb"   pos 0.0 0.0 piston_ext
 3F1B: get_car vehicle component "wheel_lb_dummy"  pos x y z
 z -= WHEEL_BZ_OFFSET
 006B: z *= damper
-3F14: set_car vehicle component "strutlb"         pos extension 0.0 z
+3F14: set_car vehicle component "strutunitlb_"    pos extension 0.0 z
 
-3F14: set_car vehicle component "strutshocklf"    pos extension 0.0 0.0
 3F14: set_car vehicle component "shockpistonlf"   pos 0.0 0.0 piston_ext
 3F1B: get_car vehicle component "wheel_lf_dummy"  pos x y z
 z -= WHEEL_FZ_OFFSET
 z *= damper
-3F14: set_car vehicle component "strutlf"         pos extension 0.0 z
+3F14: set_car vehicle component "strutunitlf_"    pos extension 0.0 z
 extension *= -1.0
 
 // Rotate wheels
-3F16: set_car vehicle component "holderrf"        angle 0.0 pivot 0.0
-3F16: set_car vehicle component "holderrb"        angle 0.0 pivot 0.0
-3F16: set_car vehicle component "brakerf"         angle 0.0 pivot 0.0
-3F16: set_car vehicle component "brakerb"         angle 0.0 pivot 0.0
-3F16: set_car vehicle component "fxwheelrf_"      angle 0.0 pivot 0.0
-3F16: set_car vehicle component "fxwheelrb_"      angle 0.0 pivot 0.0
+3F16: set_car vehicle component "hoverjointrf_"   angle 0.0 pivot 0.0
+3F16: set_car vehicle component "hoverjointrb_"   angle 0.0 pivot 0.0
 pivot *= -1.0
-3F16: set_car vehicle component "holderlf"        angle 0.0 pivot 0.0
-3F16: set_car vehicle component "holderlb"        angle 0.0 pivot 0.0
-3F16: set_car vehicle component "brakelf"         angle 0.0 pivot 0.0
-3F16: set_car vehicle component "brakelb"         angle 0.0 pivot 0.0
-3F16: set_car vehicle component "fxwheellf_"      angle 0.0 pivot 0.0
-3F16: set_car vehicle component "fxwheellb_"      angle 0.0 pivot 0.0
+3F16: set_car vehicle component "hoverjointlf_"   angle 0.0 pivot 0.0
+3F16: set_car vehicle component "hoverjointlb_"   angle 0.0 pivot 0.0
 pivot *= -1.0
 return

--- a/Delorean/Include/HoverAnimateModel.txt
+++ b/Delorean/Include/HoverAnimateModel.txt
@@ -6,38 +6,49 @@ end
 :HoverAnimateModel
 // controls how far the piston extends based on wheel rotation.
 piston_ext = pivot // Piston
-piston_ext *= -0.001
+piston_ext *= -0.000756
 
 0086: damper = extension
 damper /= -0.3
 damper += 1.0
 
 // Extend
-3F14: set_car vehicle component "shockpistonrb"   pos 0.0 0.0 piston_ext
+3F14: set_car vehicle component "shockpistonrb_"  pos 0.0 0.0 piston_ext
 3F1B: get_car vehicle component "wheel_rb_dummy"  pos x y z
 z -= WHEEL_BZ_OFFSET
 z *= damper
 3F14: set_car vehicle component "strutunitrb_"    pos extension 0.0 z
 
-3F14: set_car vehicle component "shockpistonrf"   pos 0.0 0.0 piston_ext
+3F14: set_car vehicle component "shockpistonrf_"  pos 0.0 0.0 piston_ext
 3F1B: get_car vehicle component "wheel_rf_dummy"  pos x y z
 z -= WHEEL_FZ_OFFSET
 z *= damper
 3F14: set_car vehicle component "strutunitrf_"    pos extension 0.0 z
 
 extension *= -1.0
-3F14: set_car vehicle component "shockpistonlb"   pos 0.0 0.0 piston_ext
+3F14: set_car vehicle component "shockpistonlb_"  pos 0.0 0.0 piston_ext
 3F1B: get_car vehicle component "wheel_lb_dummy"  pos x y z
 z -= WHEEL_BZ_OFFSET
 006B: z *= damper
 3F14: set_car vehicle component "strutunitlb_"    pos extension 0.0 z
 
-3F14: set_car vehicle component "shockpistonlf"   pos 0.0 0.0 piston_ext
+3F14: set_car vehicle component "shockpistonlf_"  pos 0.0 0.0 piston_ext
 3F1B: get_car vehicle component "wheel_lf_dummy"  pos x y z
 z -= WHEEL_FZ_OFFSET
 z *= damper
 3F14: set_car vehicle component "strutunitlf_"    pos extension 0.0 z
 extension *= -1.0
+
+piston_angle = pivot  // Piston
+piston_angle *= -0.002
+
+// Rotate hydraulics
+3F16: set_car vehicle component "shockrb_"        angle 0.0 piston_angle 0.0
+3F16: set_car vehicle component "shockrf_"        angle 0.0 piston_angle 0.0
+piston_angle *= -1.0
+3F16: set_car vehicle component "shocklb_"        angle 0.0 piston_angle 0.0
+3F16: set_car vehicle component "shocklf_"        angle 0.0 piston_angle 0.0
+piston_angle *= -1.0
 
 // Rotate wheels
 3F16: set_car vehicle component "hoverjointrf_"   angle 0.0 pivot 0.0

--- a/Delorean/Variation.txt
+++ b/Delorean/Variation.txt
@@ -562,21 +562,29 @@ visibility = 0
 
 // Suspension
 3F10: set_car vehicle component "strutrb" visible visibility
+3F10: set_car vehicle component "strutshockrb" visible visibility
+3F10: set_car vehicle component "hoverjointrb" visible visibility
 3F10: set_car vehicle component "holderrb" visible visibility
 3F10: set_car vehicle component "shockpistonrb" visible visibility
 3F10: set_car vehicle component "shocklb" visible visibility
 
 3F10: set_car vehicle component "strutlb" visible visibility
+3F10: set_car vehicle component "strutshocklb" visible visibility
+3F10: set_car vehicle component "hoverjointlb" visible visibility
 3F10: set_car vehicle component "holderlb" visible visibility
 3F10: set_car vehicle component "shockpistonlb" visible visibility
 3F10: set_car vehicle component "shocklb" visible visibility
 
 3F10: set_car vehicle component "strutrf" visible visibility
+3F10: set_car vehicle component "strutshockrf" visible visibility
+3F10: set_car vehicle component "hoverjointrf" visible visibility
 3F10: set_car vehicle component "holderrf" visible visibility
 3F10: set_car vehicle component "shockpistonrf" visible visibility
 3F10: set_car vehicle component "shockrf" visible visibility
 
 3F10: set_car vehicle component "strutlf" visible visibility
+3F10: set_car vehicle component "strutshocklf" visible visibility
+3F10: set_car vehicle component "hoverjointlf" visible visibility
 3F10: set_car vehicle component "holderlf" visible visibility
 3F10: set_car vehicle component "shockpistonlf" visible visibility
 3F10: set_car vehicle component "shocklf" visible visibility

--- a/Delorean/Variation.txt
+++ b/Delorean/Variation.txt
@@ -14,6 +14,7 @@ float z
 float extension
 float pivot
 float piston_ext
+float piston_angle
 float damper
 gosub @ThrusterLightsOff
 gosub @HideFuel

--- a/Delorean/Wheels.txt
+++ b/Delorean/Wheels.txt
@@ -58,7 +58,7 @@ while true
     end
 
     // Get extension of struts
-    3F1B: get_car vehicle component "strutrb" pos extension y z
+    3F1B: get_car vehicle component "strutunitrb_" pos extension y z
     damper = extension
     damper /= -0.3
     damper += 1.0
@@ -67,53 +67,39 @@ while true
     3F1B: get_car vehicle component "wheel_rf_dummy" pos x y z
     z -= WHEEL_FRONT_OFFSET
     006B: z *= damper
-    3F14: set_car vehicle component "strutrf" pos extension 0 z
+    3F14: set_car vehicle component "strutunitrf_"   pos extension 0 0
+    3F14: set_car vehicle component "strutarmrf_"    pos 0 0 z
 
     3F1B: get_car vehicle component "wheel_rb_dummy" pos x y z
     z -= WHEEL_FRONT_OFFSET
     006B: z *= damper
-    3F14: set_car vehicle component "strutrb" pos extension 0 z
+    3F14: set_car vehicle component "strutunitrb_"   pos extension 0 0
+    3F14: set_car vehicle component "strutarmrb_"    pos 0 0 z
 
     extension *= -1.0
 
     3F1B: get_car vehicle component "wheel_lf_dummy" pos x y z
     z -= WHEEL_BACK_OFFSET
     006B: z *= damper
-    3F14: set_car vehicle component "strutlf" pos extension 0 z
+    3F14: set_car vehicle component "strutunitlf_"   pos extension 0 0
+    3F14: set_car vehicle component "strutarmlf_"    pos 0 0 z
 
     3F1B: get_car vehicle component "wheel_lb_dummy" pos x y z
     z -= WHEEL_BACK_OFFSET
     006B: z *= damper
-    3F14: set_car vehicle component "strutlb" pos extension 0 z
+    3F14: set_car vehicle component "strutunitlb_"   pos extension 0 0
+    3F14: set_car vehicle component "strutarmlb_"    pos 0 0 z
 
     // Set angles
-    3F1C: get_car vehicle angle "fxwheelrf_" pos x y z
     3F36: get_car vehicle steering_angle steering
     steering *= 0.6
     006B: steering *= damper
-    3F16: set_car vehicle component "holderlf"                 angle 0 y steering
-    3F16: set_car vehicle component "brakelf"                  angle 0 y steering
-    3F16: set_car vehicle component "fxrotorlf"                angle lf 0 steering
-    3F16: set_car vehicle component "fxwheellfrimbttf1_"       angle lf 0 steering
-    3F16: set_car vehicle component "fxwheellfrimbttf3_"       angle lf 0 steering
-    3F16: set_car vehicle component "fxwheellfrimbttf3rr_"     angle lf 0 steering
-
-    3F16: set_car vehicle component "fxrotorlb"                angle lb 0 0
-    3F16: set_car vehicle component "fxwheellbrimbttf1_"       angle lb 0 0
-    3F16: set_car vehicle component "fxwheellbrimbttf3_"       angle lb 0 0
-    3F16: set_car vehicle component "fxwheellbrimbttf3rr_"     angle lb 0 0
-    y *= -1.0
-    3F16: set_car vehicle component "holderrf"                 angle 0 y steering
-    3F16: set_car vehicle component "brakerf"                  angle 0 y steering
-    3F16: set_car vehicle component "fxrotorrf"                angle rf 0 steering
-    3F16: set_car vehicle component "fxwheelrfrimbttf1_"       angle rf 0 steering
-    3F16: set_car vehicle component "fxwheelrfrimbttf3_"       angle rf 0 steering
-    3F16: set_car vehicle component "fxwheelrfrimbttf3rr_"     angle rf 0 steering
-
-    3F16: set_car vehicle component "fxrotorrb"                angle rb 0 0
-    3F16: set_car vehicle component "fxwheelrbrimbttf1_"       angle rb 0 0
-    3F16: set_car vehicle component "fxwheelrbrimbttf3_"       angle rb 0 0
-    3F16: set_car vehicle component "fxwheelrbrimbttf3rr_"     angle rb 0 0
+    3F16: set_car vehicle component "holderlf_"  angle 0 0 steering
+    3F16: set_car vehicle component "fxwheellf_" angle lf 0 0
+    3F16: set_car vehicle component "fxwheellb_" angle lb 0 0
+    3F16: set_car vehicle component "holderrf_"  angle 0 0 steering
+    3F16: set_car vehicle component "fxwheelrf_" angle rf 0 0
+    3F16: set_car vehicle component "fxwheelrb_" angle rb 0 0
 
     cleo_call @DamagedWheels 2 vehicle vehicle_flags
 end

--- a/Delorean/Wheels.txt
+++ b/Delorean/Wheels.txt
@@ -43,7 +43,7 @@ while true
         damper = 0
     end
 
-    3F1B: get_car vehicle component "strutrb" pos extension y z
+    3F1B: get_car vehicle component "strutunitrb_" pos extension y z
     0097: abs extension
     if and
         extension < 0.1

--- a/DeloreanCheck.txt
+++ b/DeloreanCheck.txt
@@ -135,7 +135,7 @@ then
 end
 
 // Flying
-3F1C: get_car vehicle component "fxwheelrb_" rotation var1 var2 var3
+3F1C: get_car vehicle component "hoverjointrb_" rotation var1 var2 var3
 0097: abs var2
 if
     var2 >= 89.0 // Wheels folded out


### PR DESCRIPTION
New hierarchy for the struts, making everything dummy-based. It's supposed to work like this:

Everything inside `strutunitxx_` should extend/retract, with the hover conversion.
Everything inside `strutarmxx_` should move up/down, with the car's suspension.
Everything inside `hoverjointxx_` should fold 90 degrees out/in, with the hover conversion.
Everything inside `holderxx_` should rotate left/right, with the car's steering.
Everything inside `fxwheelxx_` should spin forwards/backwards, with the car's wheels.

Additionally, hover conversion hydraulics have been wrapped inside new dummies `hoverhdcsxx_`, to allow piston manipulation without the game resetting angle to 0.
